### PR TITLE
Add Auto Browser Opening for Login Flow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,17 +16,19 @@
         "class-validator": "^0.14.2",
         "commander": "^13.1.0",
         "dotenv": "^16.5.0",
+        "open": "^10.1.2",
         "ora": "^8.2.0",
         "perf_hooks": "^0.0.1",
         "tar-fs": "^3.0.9",
         "update-notifier-cjs": "^5.1.7"
       },
       "bin": {
-        "opsctrl": "dist/index.js"
+        "opsctrl": "dist/opsctrl.cjs"
       },
       "devDependencies": {
         "@types/archiver": "^6.0.3",
         "@types/node": "^22.15.17",
+        "@types/open": "^6.1.0",
         "@types/update-notifier": "^6.0.8",
         "esbuild": "^0.25.5",
         "execa": "^7.1.1",
@@ -1298,6 +1300,16 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/open": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@types/open/-/open-6.1.0.tgz",
+      "integrity": "sha512-sdB0OltczakZfdn5DYg3ZbHoQeYtU8Vbo4dys0U98gikn++M4gGDI02dzEWXPMP5uXGSjGx9GnK/yLlJMfGjlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/readdir-glob": {
@@ -2716,6 +2728,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3668,6 +3695,34 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -3689,6 +3744,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -5243,6 +5310,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5273,6 +5355,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-installed-globally": {
@@ -5419,6 +5519,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6666,6 +6781,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openid-client": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.5.0.tgz",
@@ -7683,6 +7816,18 @@
         "@rollup/rollup-win32-ia32-msvc": "4.40.2",
         "@rollup/rollup-win32-x64-msvc": "4.40.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/archiver": "^6.0.3",
     "@types/node": "^22.15.17",
+    "@types/open": "^6.1.0",
     "@types/update-notifier": "^6.0.8",
     "esbuild": "^0.25.5",
     "execa": "^7.1.1",
@@ -61,6 +62,7 @@
     "class-validator": "^0.14.2",
     "commander": "^13.1.0",
     "dotenv": "^16.5.0",
+    "open": "^10.1.2",
     "ora": "^8.2.0",
     "perf_hooks": "^0.0.1",
     "tar-fs": "^3.0.9",

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,16 +1,18 @@
 import { Command } from 'commander';
 import ora from 'ora';
 import chalk from 'chalk';
+import open from 'open';
 import { isLoggedIn, login } from '../core/auth';
 import axios from 'axios';
 import { DEFAULT_API_URL } from '../core/config';
-import { delay, printErrorAndExit } from '../utils/utils';
+import { printErrorAndExit } from '../utils/utils';
 
 export function registerLoginCommand(program: Command) {
   program
     .command('login')
     .description('Authenticate with Opsctrl Cloud')
-    .action(async () => {
+    .option('--no-browser', 'Skip opening browser automatically')
+    .action(async (options) => {
       try {
         if (isLoggedIn()) {
           const spinner = ora('Starting login flow...').start();
@@ -24,11 +26,25 @@ export function registerLoginCommand(program: Command) {
 
         const { login_code, url } = data;
 
-        console.log(`\n 🔐 Open the link below in your browser to log in:`);
+        console.log(`\n 🔐 Authenticating with Opsctrl Cloud...\n`);
 
-        console.log(chalk.cyanBright(url));
+        // Auto-open browser unless --no-browser flag is used
+        if (options.browser !== false) {
+          try {
+            console.log('Opening browser...');
+            await open(url);
+            console.log(`${chalk.green('✓')} Browser opened successfully`);
+          } catch (openError) {
+            console.log(`${chalk.yellow('⚠')} Could not open browser automatically`);
+            console.log(`Please manually open: ${chalk.cyanBright(url)}`);
+          }
+        } else {
+          console.log(`Open this link in your browser:`);
+          console.log(chalk.cyanBright(url));
+        }
 
-        console.log(`\n Paste the code: ${chalk.bold(login_code)}\n`);
+        console.log(`\n${chalk.dim('Device code:')} ${chalk.bold(login_code)}`);
+        console.log(`${chalk.dim('The code should auto-fill in your browser')}\n`);
 
         const spinner = ora('Waiting for authentication...').start();
 
@@ -37,7 +53,7 @@ export function registerLoginCommand(program: Command) {
         await login(spinner, login_code);
         spinner.succeed('Logged in successfully.');
       } catch (err: any) {
-        if (err.cause.code === 'ECONNREFUSED') {
+        if (err.cause?.code === 'ECONNREFUSED') {
           printErrorAndExit(
             'Could not connect to the authentication server. Please check your network connection.',
           );


### PR DESCRIPTION
## Summary
Enhances the `opsctrl login` command to automatically open the user's default browser to the authentication URL, improving UX by eliminating manual copy-paste steps.

## Changes
- **Auto Browser Opening**: Added `open` package integration to launch default browser automatically
- **User Control**: Added `--no-browser` flag for users who prefer manual URL handling
- **Graceful Fallback**: Falls back to manual URL display if browser opening fails

## Key Features
- Cross-platform browser opening (Windows, macOS, Linux)
- Automatic fallback for headless environments (SSH sessions)
- User control with `--no-browser` option

## Dependencies
- Added `open` package for cross-platform browser launching

## Usage
```bash
# Auto-opens browser (default)
opsctrl login

# Skip auto browser opening
opsctrl login --no-browser
```